### PR TITLE
add access list caching

### DIFF
--- a/steel/src/config.rs
+++ b/steel/src/config.rs
@@ -45,6 +45,18 @@ pub static ETH_SEPOLIA_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
     gas_constants: BTreeMap::from([(SpecId::LONDON, EIP1559_CONSTANTS_DEFAULT)]),
 });
 
+// source: https://github.com/eth-clients/holesky
+pub static ETH_HOLESKY_CHAIN_SPEC: Lazy<ChainSpec> = Lazy::new(|| ChainSpec {
+    chain_id: 17000,
+    max_spec_id: SpecId::CANCUN,
+    hard_forks: BTreeMap::from([
+        (SpecId::MERGE, ForkCondition::Block(0)), //merged from genesis
+        (SpecId::SHANGHAI, ForkCondition::Timestamp(1696000704)),
+        (SpecId::CANCUN, ForkCondition::Timestamp(1707305664)),
+    ]),
+    gas_constants: BTreeMap::from([(SpecId::LONDON, EIP1559_CONSTANTS_DEFAULT)]),
+});
+
 /// The gas constants as defined in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559).
 pub const EIP1559_CONSTANTS_DEFAULT: Eip1559Constants = Eip1559Constants {
     base_fee_change_denominator: 8,

--- a/steel/src/host/provider/file.rs
+++ b/steel/src/host/provider/file.rs
@@ -192,7 +192,8 @@ impl<P: Provider> CachedProvider<P>
 where
     P::Header: Clone + Serialize + DeserializeOwned,
 {
-    pub fn populate_accounts_and_storage(
+    // populate the cache with balance, nonce, and storage values for the acounts and storage keys in the access list
+    pub fn cache_access_list(
         &self,
         access_list: AccessList,
         block: BlockNumber,


### PR DESCRIPTION
allows users to populate the a CachedProvider's cache with the balance, nonce, and storage values for the accounts and storage keys in a provided access list

1. is the current cache update behavior correct? (panic on overwriting with new value)
2. should access list creation live within or outside of steel?